### PR TITLE
add backstage documentation and pull requests templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Team Sol is taking ownership over password strength fork
 # This will notify us of any requested changes to anything
-* @cultureamp/team-sol
+* @cultureamp/sol

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Team Sol is taking ownership over password strength fork
+# This will notify us of any requested changes to anything
+* @cultureamp/team-sol

--- a/.github/pull_request_checklist.md
+++ b/.github/pull_request_checklist.md
@@ -1,0 +1,27 @@
+# Pull Request Checklist Details
+
+Here are some useful questions to ask before merging a Pull Request.
+
+## [Security](https://cultureamp.atlassian.net/wiki/spaces/SEC/pages/963641883/Security+Partnership+Process)
+- [Do we need an AppSec review?](https://cultureamp.atlassian.net/servicedesk/customer/portal/5/group/39/create/461)
+- Have we modified authentication, authorization, filtering?
+- Could there be any PII leaks through tracking or logging?
+  
+## Acceptance Criteria
+- What is the acceptance criteria?
+- How can we verify the PR has the desired effect?
+- Are we sure there are no undesired side effects?
+  
+## Tests
+- Do we have appropriate tests?
+- How much of the new code do they cover?
+- What gaps do you need to call out?
+
+## Logging
+- Are we logging the right things?
+- Are we using structured logging?
+
+## Involve Others
+- [Do we need a Change Management Request?](https://cultureamp.atlassian.net/servicedesk/customer/portal/30)
+- Does the tech lead need to see this?
+- Do other teams need to see this?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+
+ Just fill in only the relevant sections unless you are linking to trello/jira
+
+-->
+
+## Purpose
+<!--
+What is the objective of the Pull Request?
+-->
+
+## Context
+<!--
+Why are we making this change? 
+Is there jira/trello, bugsnag or slack link you can put here?
+If it was a bug, what caused it?
+-->
+
+## Changes
+<!--
+What were the changes you made? (Omit section if this is clear from the commits already.)
+-->
+
+## Verification
+<!--
+Any exceptions to testing norms?
+Where should QA focus?
+-->
+
+## Checklist
+- [Security](pull_request_checklist.md#security)
+- [Acceptance Criteria](pull_request_checklist.md#acceptance%20criteria)
+- [Tests](pull_request_checklist.md#tests)
+- [Logging](pull_request_checklist.md#logging)
+- [Involve Others](pull_request_checklist.md#involve%20others)

--- a/catalog-info-component.yaml
+++ b/catalog-info-component.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: password_strength
+  description: Forked password_strength gem with ruby 3 support
+  links:
+    - title: Github
+      url: https://github.com/cultureamp/password_strength
+  tags:
+    - users-internal
+    - camp-engagement
+    - data-none
+  annotations:
+    github.com/project-slug: cultureamp/password_strength
+    github.com/team-slug: cultureamp/sol
+spec:
+  type: library
+  owner: sol
+  lifecycle: development

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: password_strength-location
+  tags:
+    - camp-engagement
+spec:
+  targets:
+    - ./catalog-info-component.yaml # this is your main component file


### PR DESCRIPTION
## Purpose
Document this repo in backstage and add some templates

## Context
This gem is used by https://github.com/cultureamp/murmur. We are upgrading it to Ruby 3.0 and there is a breaking change that need to be fixed. Just gem is not maintained anymore, so we will use this forked version instead

## Verfication
Is it cataloged in Backstage