### PR TITLE
[SOL-123] fix incompatibilities with ruby 3.0

### DIFF
--- a/lib/password_strength/active_model.rb
+++ b/lib/password_strength/active_model.rb
@@ -12,7 +12,7 @@ module ActiveModel # :nodoc:
           :record => record
         )
         strength.test
-        record.errors.add(attribute, :too_weak, options) unless PasswordStrength.enabled && strength.valid?(level(record))
+        record.errors.add(attribute, :too_weak, **options) unless PasswordStrength.enabled && strength.valid?(level(record))
       end
 
       def check_validity!


### PR DESCRIPTION
# Purpose
make the gem compatible with ruby 3.0.4

breaking change:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

# Context
We are upgrading [murmur](github.com/cultureamp/murmur) to ruby 3.0.4 and we need to fix this gem's compatibility

# Verification
- works on ruby 3.0.4
- works on ruby 2.7.5