### PR TITLE
Mark data classification as public

### DIFF
--- a/catalog-info-component.yaml
+++ b/catalog-info-component.yaml
@@ -8,7 +8,7 @@ metadata:
       url: https://github.com/cultureamp/password_strength
   tags:
     - camp-engagement
-    - data-none
+    - data-public
     - users-internal
   annotations:
     github.com/project-slug: cultureamp/password_strength


### PR DESCRIPTION
Making the data classification for this open-source repo "public" after a chat with @bmendes3 who has been auditing some of our public repos.